### PR TITLE
Release 0.2.2: support the Datasette 1.0 line

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        datasette-version: ["<1", ">=1.0a0"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,6 +24,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install '.[test]'
+    - name: Install Datasette ${{ matrix.datasette-version }}
+      run: |
+        pip install --pre "datasette${{ matrix.datasette-version }}"
     - name: Run tests
       run: |
         python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Write every entry in Simplified Technical English. Apply the
 `simplified-technical-english` skill before you add or edit an entry. See
 [AGENTS.md](AGENTS.md) for the rule.
 
+## [0.2.2] - 2026-08-17
+
+### Changed
+
+- Change the Datasette requirement to `datasette>=0.64`. The plugin now installs on
+  both the Datasette 0.x line and the 1.0 line. To install on a 1.0 alpha, use
+  `pip install --pre`.
+- Add a Datasette version to the CI matrix. The tests now run against a 0.x release
+  and the newest 1.0 alpha. This step keeps both lines supported.
+
 ## [0.2.1] - 2026-08-14
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,19 @@ install:
 check:
 	uv run ruff check --fix datasette_marimo/
 	uv run pytest
+
+# Run the tests against the Datasette 0.x line.
+check-v0:
+	uv run --extra test --with "datasette<1" pytest
+
+# Run the tests against the Datasette 1.0 line (newest alpha).
+check-v1:
+	uv run --extra test --prerelease=allow --with "datasette>=1.0a0" pytest
+
+# Run the tests against both Datasette lines, like the CI matrix.
+check-both: check-v0 check-v1
+
+# Primary test entrypoint: lint, then test both Datasette lines.
+test:
+	uv run --extra test ruff check datasette_marimo/
+	$(MAKE) check-both

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datasette-marimo"
-version = "0.2.1"
+version = "0.2.2"
 description = "Marimo attached to your datasette"
 readme = "README.md"
 authors = [{name = "Vincent D. Warmerdam"}]
@@ -14,7 +14,7 @@ requires-python = ">=3.9"
 # (marimo, moutils, httpx, polars, ...) is declared in the notebooks' inline
 # script metadata and installed in the browser by the WASM runtime.
 dependencies = [
-    "datasette>=0.64,<1"
+    "datasette>=0.64"
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "datasette-marimo"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "datasette" },
@@ -146,7 +146,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datasette", specifier = ">=0.64,<1" },
+    { name = "datasette", specifier = ">=0.64" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-asyncio", marker = "extra == 'test'" },
     { name = "ruff", marker = "extra == 'test'" },


### PR DESCRIPTION
Widen the requirement to `datasette>=0.64`, so the plugin installs on both the Datasette 0.x line and the 1.0 line. The server plugin only uses hooks that are stable across both lines, so no plugin code changes. Add a Datasette version to the CI matrix, so the tests run against a 0.x release and the newest 1.0 alpha. Add `make test` and the `check-v0` / `check-v1` / `check-both` targets to run the same tests on your machine. Bump the version to 0.2.2 and add a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)